### PR TITLE
JAVA-2901: Marked ChangeStreamDocument.getFullDocument as @Nullable

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocument.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocument.java
@@ -120,6 +120,7 @@ public final class ChangeStreamDocument<TDocument> {
      *
      * @return the fullDocument
      */
+    @Nullable
     public TDocument getFullDocument() {
         return fullDocument;
     }


### PR DESCRIPTION
Annotated getFullDocument() in ChangeStreamDocument as Nullable. 

[Evergreen Patch Build](https://evergreen.mongodb.com/version/5b8ee4292fbabe338825fbbe)