### PR TITLE
JAVA-2912: Update com.mongodb.client.MongoClient to extend Closeable

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/MongoClient.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoClient.java
@@ -22,6 +22,7 @@ import com.mongodb.annotations.Immutable;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
+import java.io.Closeable;
 import java.util.List;
 
 /**
@@ -38,7 +39,7 @@ import java.util.List;
  * @since 3.7
  */
 @Immutable
-public interface MongoClient {
+public interface MongoClient extends Closeable {
 
     /**
      * Gets a {@link MongoDatabase} instance for the given database name.
@@ -101,7 +102,6 @@ public interface MongoClient {
      * @return the list databases iterable interface
      */
     ListDatabasesIterable<Document> listDatabases();
-
     /**
      * Gets the list of databases
      *

--- a/driver-sync/src/main/com/mongodb/client/MongoClient.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoClient.java
@@ -102,6 +102,7 @@ public interface MongoClient extends Closeable {
      * @return the list databases iterable interface
      */
     ListDatabasesIterable<Document> listDatabases();
+
     /**
      * Gets the list of databases
      *


### PR DESCRIPTION
Updated the MongoClient class in driver-sync to extend Closeable. 

[Evergreen Patch Build](https://evergreen.mongodb.com/version/5b90113d0305b93c4c5eaf07)