### PR TITLE
JAVA-2926: Add support for readConcern level "available"

### DIFF
--- a/driver-core/src/main/com/mongodb/ReadConcern.java
+++ b/driver-core/src/main/com/mongodb/ReadConcern.java
@@ -77,6 +77,14 @@ public final class ReadConcern {
     public static final ReadConcern SNAPSHOT = new ReadConcern(ReadConcernLevel.SNAPSHOT);
 
     /**
+     * The available read concern.
+     *
+     * @since 3.9
+     * @mongodb.server.release 3.6
+     */
+    public static final ReadConcern AVAILABLE = new ReadConcern(ReadConcernLevel.AVAILABLE);
+
+    /**
      * Gets the read concern level.
      *
      * @return the read concern level, which may be null (which indicates to use the server's default level)

--- a/driver-core/src/main/com/mongodb/ReadConcernLevel.java
+++ b/driver-core/src/main/com/mongodb/ReadConcernLevel.java
@@ -56,7 +56,15 @@ public enum ReadConcernLevel {
      * @since 3.8
      * @mongodb.server.release 4.0
      */
-    SNAPSHOT("snapshot");
+    SNAPSHOT("snapshot"),
+
+    /**
+     * The available read concern level.
+     *
+     * @since 3.9
+     * @mongodb.server.release 3.6
+     */
+    AVAILABLE("available");
 
     private final String value;
 

--- a/driver-core/src/test/resources/read-concern/connection-string/read-concern.json
+++ b/driver-core/src/test/resources/read-concern/connection-string/read-concern.json
@@ -24,6 +24,24 @@
       "readConcern": {
         "level": "majority"
       }
+    },
+    {
+      "description": "linearizable specified",
+      "uri": "mongodb://localhost/?readConcernLevel=linearizable",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "linearizable"
+      }
+    },
+    {
+      "description": "available specified",
+      "uri": "mongodb://localhost/?readConcernLevel=available",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "available"
+      }
     }
   ]
 }

--- a/driver-core/src/test/resources/read-concern/document/read-concern.json
+++ b/driver-core/src/test/resources/read-concern/document/read-concern.json
@@ -28,6 +28,39 @@
         "level": "local"
       },
       "isServerDefault": false
+    },
+    {
+      "description": "Linearizable",
+      "valid": true,
+      "readConcern": {
+        "level": "linearizable"
+      },
+      "readConcernDocument": {
+        "level": "linearizable"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Snapshot",
+      "valid": true,
+      "readConcern": {
+        "level": "snapshot"
+      },
+      "readConcernDocument": {
+        "level": "snapshot"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Available",
+      "valid": true,
+      "readConcern": {
+        "level": "available"
+      },
+      "readConcernDocument": {
+        "level": "available"
+      },
+      "isServerDefault": false
     }
   ]
 }

--- a/driver-core/src/test/unit/com/mongodb/ReadConcernLevelSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ReadConcernLevelSpecification.groovy
@@ -30,6 +30,7 @@ class ReadConcernLevelSpecification extends Specification {
         ReadConcernLevel.MAJORITY     | 'majority'
         ReadConcernLevel.LINEARIZABLE | 'linearizable'
         ReadConcernLevel.SNAPSHOT     | 'snapshot'
+        ReadConcernLevel.AVAILABLE    | 'available'
     }
 
     def 'should support valid string representations'() {
@@ -37,7 +38,8 @@ class ReadConcernLevelSpecification extends Specification {
         ReadConcernLevel.fromString(readConcernLevel) instanceof ReadConcernLevel
 
         where:
-        readConcernLevel << ['local', 'majority', 'linearizable', 'snapshot', 'LOCAL', 'MAJORITY', 'LINEARIZABLE', 'SNAPSHOT']
+        readConcernLevel << ['local', 'majority', 'linearizable', 'snapshot', 'available', 'LOCAL', 'MAJORITY',
+                             'LINEARIZABLE', 'SNAPSHOT', 'AVAILABLE']
     }
 
     def 'should throw an illegal Argument exception for invalid values'() {

--- a/driver-core/src/test/unit/com/mongodb/ReadConcernSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ReadConcernSpecification.groovy
@@ -33,6 +33,7 @@ class ReadConcernSpecification extends Specification {
         ReadConcern.MAJORITY     | ReadConcernLevel.MAJORITY     | new ReadConcern(ReadConcernLevel.MAJORITY)
         ReadConcern.LINEARIZABLE | ReadConcernLevel.LINEARIZABLE | new ReadConcern(ReadConcernLevel.LINEARIZABLE)
         ReadConcern.SNAPSHOT     | ReadConcernLevel.SNAPSHOT     | new ReadConcern(ReadConcernLevel.SNAPSHOT)
+        ReadConcern.AVAILABLE    | ReadConcernLevel.AVAILABLE    | new ReadConcern(ReadConcernLevel.AVAILABLE)
     }
 
     def 'should create the expected Documents'() {
@@ -46,6 +47,7 @@ class ReadConcernSpecification extends Specification {
         ReadConcern.MAJORITY     | BsonDocument.parse('{level: "majority"}')
         ReadConcern.LINEARIZABLE | BsonDocument.parse('{level: "linearizable"}')
         ReadConcern.SNAPSHOT     | BsonDocument.parse('{level: "snapshot"}')
+        ReadConcern.AVAILABLE    | BsonDocument.parse('{level: "available"}')
     }
 
     def 'should have the correct value for isServerDefault'() {
@@ -59,5 +61,6 @@ class ReadConcernSpecification extends Specification {
         ReadConcern.MAJORITY     | false
         ReadConcern.LINEARIZABLE | false
         ReadConcern.SNAPSHOT     | false
+        ReadConcern.AVAILABLE    | false
     }
 }


### PR DESCRIPTION
This change adds support for the "available" readConcern level. The spec tests were also updated, since they were missing a few readConcern levels.


[Evergreen Patch](https://evergreen.mongodb.com/version/5b9292972a60ed2c279c5774)