### PR TITLE
JAVA-2917: Allow BsonBinary to be created from UUIDs

### DIFF
--- a/bson/src/main/org/bson/BsonBinary.java
+++ b/bson/src/main/org/bson/BsonBinary.java
@@ -16,6 +16,7 @@
 
 package org.bson;
 
+import org.bson.assertions.Assertions;
 import org.bson.internal.UuidHelper;
 
 import java.util.Arrays;
@@ -82,6 +83,8 @@ public class BsonBinary extends BsonValue {
      * Construct a Type 4 BsonBinary from the given UUID.
      *
      * @param uuid the UUID
+     *
+     * @since 3.9
      */
     public BsonBinary(final UUID uuid) {
         this(uuid, UuidRepresentation.STANDARD);
@@ -92,6 +95,9 @@ public class BsonBinary extends BsonValue {
      *
      * @param uuid the UUID
      * @param uuidRepresentation the UUID representation
+     *
+     *
+     * @since 3.9
      */
     public BsonBinary(final UUID uuid, final UuidRepresentation uuidRepresentation) {
         if (uuid == null) {
@@ -110,10 +116,16 @@ public class BsonBinary extends BsonValue {
      * Returns the binary as a UUID. The binary type must be 4.
      *
      * @return the uuid
+     *
+     * @since 3.9
      */
     public UUID asUuid() {
+        if (!BsonBinarySubType.isUuid(type)) {
+            throw new BsonInvalidOperationException("type must be a UUID subtype.");
+        }
+
         if (type != BsonBinarySubType.UUID_STANDARD.getValue()) {
-            throw new BsonInvalidOperationException("BsonBinarySubType must be UUID_STANDARD.");
+            throw new BsonInvalidOperationException("uuidRepresentation must be set to return the correct UUID.");
         }
 
         return UuidHelper.decodeBinaryToUuid(this.data.clone(), this.type, UuidRepresentation.STANDARD);
@@ -124,11 +136,11 @@ public class BsonBinary extends BsonValue {
      *
      * @param uuidRepresentation the UUID representation
      * @return the uuid
+     *
+     * @since 3.9
      */
     public UUID asUuid(final UuidRepresentation uuidRepresentation) {
-        if (uuidRepresentation == null) {
-            throw new IllegalArgumentException("uuidRepresentation may not be null");
-        }
+        Assertions.notNull("uuidRepresentation", uuidRepresentation);
 
         final byte uuidType = uuidRepresentation == UuidRepresentation.STANDARD
                 ? BsonBinarySubType.UUID_STANDARD.getValue()
@@ -138,7 +150,7 @@ public class BsonBinary extends BsonValue {
             throw new BsonInvalidOperationException("uuidRepresentation does not match current uuidRepresentation.");
         }
 
-        return UuidHelper.decodeBinaryToUuid(this.data.clone(), this.type, uuidRepresentation);
+        return UuidHelper.decodeBinaryToUuid(data.clone(), type, uuidRepresentation);
     }
 
     @Override

--- a/bson/src/main/org/bson/BsonBinary.java
+++ b/bson/src/main/org/bson/BsonBinary.java
@@ -83,7 +83,6 @@ public class BsonBinary extends BsonValue {
      * Construct a Type 4 BsonBinary from the given UUID.
      *
      * @param uuid the UUID
-     *
      * @since 3.9
      */
     public BsonBinary(final UUID uuid) {
@@ -95,8 +94,6 @@ public class BsonBinary extends BsonValue {
      *
      * @param uuid the UUID
      * @param uuidRepresentation the UUID representation
-     *
-     *
      * @since 3.9
      */
     public BsonBinary(final UUID uuid, final UuidRepresentation uuidRepresentation) {
@@ -116,7 +113,6 @@ public class BsonBinary extends BsonValue {
      * Returns the binary as a UUID. The binary type must be 4.
      *
      * @return the uuid
-     *
      * @since 3.9
      */
     public UUID asUuid() {
@@ -136,7 +132,6 @@ public class BsonBinary extends BsonValue {
      *
      * @param uuidRepresentation the UUID representation
      * @return the uuid
-     *
      * @since 3.9
      */
     public UUID asUuid(final UuidRepresentation uuidRepresentation) {

--- a/bson/src/main/org/bson/codecs/UuidCodec.java
+++ b/bson/src/main/org/bson/codecs/UuidCodec.java
@@ -20,13 +20,12 @@ import org.bson.BSONException;
 import org.bson.BsonBinary;
 import org.bson.BsonBinarySubType;
 import org.bson.BsonReader;
-import org.bson.BsonSerializationException;
 import org.bson.BsonWriter;
 import org.bson.UuidRepresentation;
 
-import java.util.UUID;
+import org.bson.internal.UuidHelper;
 
-import static org.bson.codecs.UuidCodecHelper.reverseByteArray;
+import java.util.UUID;
 
 /**
  * Encodes and decodes {@code UUID} objects.
@@ -59,25 +58,7 @@ public class UuidCodec implements Codec<UUID> {
 
     @Override
     public void encode(final BsonWriter writer, final UUID value, final EncoderContext encoderContext) {
-        byte[] binaryData = new byte[16];
-        writeLongToArrayBigEndian(binaryData, 0, value.getMostSignificantBits());
-        writeLongToArrayBigEndian(binaryData, 8, value.getLeastSignificantBits());
-        switch (encoderUuidRepresentation) {
-            case C_SHARP_LEGACY:
-                UuidCodecHelper.reverseByteArray(binaryData, 0, 4);
-                UuidCodecHelper.reverseByteArray(binaryData, 4, 2);
-                UuidCodecHelper.reverseByteArray(binaryData, 6, 2);
-                break;
-            case JAVA_LEGACY:
-                UuidCodecHelper.reverseByteArray(binaryData, 0, 8);
-                UuidCodecHelper.reverseByteArray(binaryData, 8, 8);
-                break;
-            case PYTHON_LEGACY:
-            case STANDARD:
-                break;
-            default:
-                throw new BSONException("Unexpected UUID representation");
-        }
+        byte[] binaryData = UuidHelper.encodeUuidToBinary(value, encoderUuidRepresentation);
         // changed the default subtype to STANDARD since 3.0
         if (encoderUuidRepresentation == UuidRepresentation.STANDARD) {
             writer.writeBinaryData(new BsonBinary(BsonBinarySubType.UUID_STANDARD, binaryData));
@@ -96,59 +77,11 @@ public class UuidCodec implements Codec<UUID> {
 
         byte[] bytes = reader.readBinaryData().getData();
 
-        if (bytes.length != 16) {
-            throw new BsonSerializationException(String.format("Expected length to be 16, not %d.", bytes.length));
-        }
-
-        if (subType == BsonBinarySubType.UUID_LEGACY.getValue()) {
-            switch (decoderUuidRepresentation) {
-                case C_SHARP_LEGACY:
-                    reverseByteArray(bytes, 0, 4);
-                    reverseByteArray(bytes, 4, 2);
-                    reverseByteArray(bytes, 6, 2);
-                    break;
-                case JAVA_LEGACY:
-                    reverseByteArray(bytes, 0, 8);
-                    reverseByteArray(bytes, 8, 8);
-                    break;
-                case PYTHON_LEGACY:
-                case STANDARD:
-                    break;
-                default:
-                    throw new BSONException("Unexpected UUID representation");
-            }
-        }
-
-        return new UUID(readLongFromArrayBigEndian(bytes, 0), readLongFromArrayBigEndian(bytes, 8));
+        return UuidHelper.decodeBinaryToUuid(bytes, subType, decoderUuidRepresentation);
     }
 
     @Override
     public Class<UUID> getEncoderClass() {
         return UUID.class;
     }
-
-    private static void writeLongToArrayBigEndian(final byte[] bytes, final int offset, final long x) {
-        bytes[offset + 7] = (byte) (0xFFL & (x));
-        bytes[offset + 6] = (byte) (0xFFL & (x >> 8));
-        bytes[offset + 5] = (byte) (0xFFL & (x >> 16));
-        bytes[offset + 4] = (byte) (0xFFL & (x >> 24));
-        bytes[offset + 3] = (byte) (0xFFL & (x >> 32));
-        bytes[offset + 2] = (byte) (0xFFL & (x >> 40));
-        bytes[offset + 1] = (byte) (0xFFL & (x >> 48));
-        bytes[offset] = (byte) (0xFFL & (x >> 56));
-    }
-
-    private static long readLongFromArrayBigEndian(final byte[] bytes, final int offset) {
-        long x = 0;
-        x |= (0xFFL & bytes[offset + 7]);
-        x |= (0xFFL & bytes[offset + 6]) << 8;
-        x |= (0xFFL & bytes[offset + 5]) << 16;
-        x |= (0xFFL & bytes[offset + 4]) << 24;
-        x |= (0xFFL & bytes[offset + 3]) << 32;
-        x |= (0xFFL & bytes[offset + 2]) << 40;
-        x |= (0xFFL & bytes[offset + 1]) << 48;
-        x |= (0xFFL & bytes[offset]) << 56;
-        return x;
-    }
-
 }

--- a/bson/src/main/org/bson/internal/UuidHelper.java
+++ b/bson/src/main/org/bson/internal/UuidHelper.java
@@ -25,10 +25,6 @@ import java.util.UUID;
 
 /**
  * Utilities for encoding and decoding UUID into binary.
- *
- * <p>
- * This class is not part of the public API and may be removed or changed at any time.
- * </p>
  */
 
 public final class UuidHelper {

--- a/bson/src/main/org/bson/internal/UuidHelper.java
+++ b/bson/src/main/org/bson/internal/UuidHelper.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.internal;
+
+import org.bson.UuidRepresentation;
+import org.bson.BSONException;
+import org.bson.BsonSerializationException;
+import org.bson.BsonBinarySubType;
+
+import java.util.UUID;
+
+/**
+ * Utilities for encoding and decoding UUID into binary.
+ *
+ * <p>
+ * This class is not part of the public API and may be removed or changed at any time.
+ * </p>
+ */
+
+public final class UuidHelper {
+    private static void writeLongToArrayBigEndian(final byte[] bytes, final int offset, final long x) {
+        bytes[offset + 7] = (byte) (0xFFL & (x));
+        bytes[offset + 6] = (byte) (0xFFL & (x >> 8));
+        bytes[offset + 5] = (byte) (0xFFL & (x >> 16));
+        bytes[offset + 4] = (byte) (0xFFL & (x >> 24));
+        bytes[offset + 3] = (byte) (0xFFL & (x >> 32));
+        bytes[offset + 2] = (byte) (0xFFL & (x >> 40));
+        bytes[offset + 1] = (byte) (0xFFL & (x >> 48));
+        bytes[offset] = (byte) (0xFFL & (x >> 56));
+    }
+
+    private static long readLongFromArrayBigEndian(final byte[] bytes, final int offset) {
+        long x = 0;
+        x |= (0xFFL & bytes[offset + 7]);
+        x |= (0xFFL & bytes[offset + 6]) << 8;
+        x |= (0xFFL & bytes[offset + 5]) << 16;
+        x |= (0xFFL & bytes[offset + 4]) << 24;
+        x |= (0xFFL & bytes[offset + 3]) << 32;
+        x |= (0xFFL & bytes[offset + 2]) << 40;
+        x |= (0xFFL & bytes[offset + 1]) << 48;
+        x |= (0xFFL & bytes[offset]) << 56;
+        return x;
+    }
+
+    // reverse elements in the subarray data[start:start+length]
+    private static void reverseByteArray(final byte[] data, final int start, final int length) {
+        for (int left = start, right = start + length - 1; left < right; left++, right--) {
+            // swap the values at the left and right indices
+            byte temp = data[left];
+            data[left]  = data[right];
+            data[right] = temp;
+        }
+    }
+
+    public static byte[] encodeUuidToBinary(final UUID uuid, final UuidRepresentation uuidRepresentation) {
+        byte[] binaryData = new byte[16];
+        writeLongToArrayBigEndian(binaryData, 0, uuid.getMostSignificantBits());
+        writeLongToArrayBigEndian(binaryData, 8, uuid.getLeastSignificantBits());
+        switch(uuidRepresentation) {
+            case C_SHARP_LEGACY:
+                reverseByteArray(binaryData, 0, 4);
+                reverseByteArray(binaryData, 4, 2);
+                reverseByteArray(binaryData, 6, 2);
+                break;
+            case JAVA_LEGACY:
+                reverseByteArray(binaryData, 0, 8);
+                reverseByteArray(binaryData, 8, 8);
+                break;
+            case PYTHON_LEGACY:
+            case STANDARD:
+                break;
+            default:
+                throw new BSONException("Unexpected UUID representation");
+        }
+
+        return binaryData;
+    }
+
+    public static UUID decodeBinaryToUuid(final byte[] data, final byte type, final UuidRepresentation uuidRepresentation) {
+        if (data.length != 16) {
+            throw new BsonSerializationException(String.format("Expected length to be 16, not %d.", data.length));
+        }
+
+        if (type == BsonBinarySubType.UUID_LEGACY.getValue()) {
+            switch(uuidRepresentation) {
+                case C_SHARP_LEGACY:
+                    reverseByteArray(data, 0, 4);
+                    reverseByteArray(data, 4, 2);
+                    reverseByteArray(data, 6, 2);
+                    break;
+                case JAVA_LEGACY:
+                    reverseByteArray(data, 0, 8);
+                    reverseByteArray(data, 8, 8);
+                    break;
+                case PYTHON_LEGACY:
+                case STANDARD:
+                    break;
+                default:
+                    throw new BSONException("Unexpected UUID representation");
+            }
+        }
+
+        return new UUID(readLongFromArrayBigEndian(data, 0), readLongFromArrayBigEndian(data, 8));
+    }
+
+    private UuidHelper() {
+    }
+}

--- a/bson/src/main/org/bson/internal/UuidHelper.java
+++ b/bson/src/main/org/bson/internal/UuidHelper.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 /**
  * Utilities for encoding and decoding UUID into binary.
  */
-
 public final class UuidHelper {
     private static void writeLongToArrayBigEndian(final byte[] bytes, final int offset, final long x) {
         bytes[offset + 7] = (byte) (0xFFL & (x));

--- a/bson/src/test/unit/org/bson/BsonBinarySpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonBinarySpecification.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BsonBinarySpecification extends Specification {
+
+    @Unroll
+    def 'should initialize with data'() {
+        given:
+        def bsonBinary = new BsonBinary((byte) 80, data as byte[])
+
+        expect:
+        data == bsonBinary.getData()
+
+        where:
+        data << [
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                [2, 5, 4, 67, 3, 4, 5, 2, 4, 2, 5, 6, 7, 4, 5, 12],
+                [34, 24, 56, 76, 3, 4, 1, 12, 1, 9, 8, 7, 56, 46, 3, 9]
+        ]
+    }
+
+    @Unroll
+    def 'should initialize with data and BsonBinarySubType'() {
+        given:
+        byte[] data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        def bsonBinary = new BsonBinary(subType, data)
+
+        expect:
+        subType.getValue() == bsonBinary.getType()
+        data == bsonBinary.getData()
+
+        where:
+        subType << [BsonBinarySubType.BINARY, BsonBinarySubType.FUNCTION, BsonBinarySubType.MD5,
+                    BsonBinarySubType.OLD_BINARY, BsonBinarySubType.USER_DEFINED, BsonBinarySubType.UUID_LEGACY,
+                    BsonBinarySubType.UUID_STANDARD]
+    }
+
+    @Unroll
+    def 'should initialize with UUID'() {
+        given:
+        def bsonBinary = new BsonBinary(uuid)
+
+        expect:
+        uuid == bsonBinary.asUuid()
+
+        where:
+        uuid << [UUID.fromString('ffadee18-b533-11e8-96f8-529269fb1459'),
+                 UUID.fromString('a5dc280e-b534-11e8-96f8-529269fb1459'),
+                 UUID.fromString('4ef2a357-cb16-45a6-a6f6-a11ae1972917')]
+    }
+
+    @Unroll
+    def 'should initialize with UUID and UUID representation'() {
+        given:
+        def uuid = UUID.fromString('ffadee18-b533-11e8-96f8-529269fb1459')
+        def bsonBinary = new BsonBinary(uuid, uuidRepresentation)
+
+        expect:
+        uuid == bsonBinary.asUuid(uuidRepresentation)
+
+        where:
+        uuidRepresentation << [UuidRepresentation.STANDARD, UuidRepresentation.C_SHARP_LEGACY,
+                               UuidRepresentation.JAVA_LEGACY, UuidRepresentation.PYTHON_LEGACY]
+    }
+}

--- a/bson/src/test/unit/org/bson/internal/UuidHelperSpecification.groovy
+++ b/bson/src/test/unit/org/bson/internal/UuidHelperSpecification.groovy
@@ -1,0 +1,40 @@
+package org.bson.internal
+
+import org.bson.UuidRepresentation
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class UuidHelperSpecification extends Specification {
+
+    @Unroll
+    def 'should encode different types of UUID'() {
+        given:
+        def expectedUuid = UUID.fromString('08070605-0403-0201-100f-0e0d0c0b0a09')
+
+        expect:
+        bytes == UuidHelper.encodeUuidToBinary(expectedUuid, uuidRepresentation)
+
+        where:
+        bytes                                                   | uuidRepresentation
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] | UuidRepresentation.JAVA_LEGACY
+        [8, 7, 6, 5, 4, 3, 2, 1, 16, 15, 14, 13, 12, 11, 10, 9] | UuidRepresentation.STANDARD
+        [8, 7, 6, 5, 4, 3, 2, 1, 16, 15, 14, 13, 12, 11, 10, 9] | UuidRepresentation.PYTHON_LEGACY
+        [5, 6, 7, 8, 3, 4, 1, 2, 16, 15, 14, 13, 12, 11, 10, 9] | UuidRepresentation.C_SHARP_LEGACY
+    }
+
+    @Unroll
+    def 'should decode different types of UUID'() {
+        given:
+        byte[] expectedBytes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+
+        expect:
+        uuid == UuidHelper.decodeBinaryToUuid(expectedBytes, (byte) type, uuidRepresentation)
+
+        where:
+        uuid                                                          | type | uuidRepresentation
+        UUID.fromString('08070605-0403-0201-100f-0e0d0c0b0a09') | 3    | UuidRepresentation.JAVA_LEGACY
+        UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10') | 4    | UuidRepresentation.STANDARD
+        UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10') | 3    | UuidRepresentation.PYTHON_LEGACY
+        UUID.fromString('04030201-0605-0807-090a-0b0c0d0e0f10') | 3    | UuidRepresentation.C_SHARP_LEGACY
+    }
+}


### PR DESCRIPTION
This commit enhances the BsonBinary class to allow instances to be created from a UUID and to convert instances to a UUID. There is a bit of refactoring since a lot of the code for the encode and decode methods in UuidCodec could be reused for this.

[Evergreen Patch](https://evergreen.mongodb.com/version/5b96e4be2a60ed56ff725da3)
