### PR TITLE
JAVA-2700: Implement ip address fallback for hostnames in async

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoClientException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
 import com.mongodb.MongoInterruptedException;
+import com.mongodb.MongoSocketException;
 import com.mongodb.MongoSocketOpenException;
 import com.mongodb.MongoSocketReadTimeoutException;
 import com.mongodb.ServerAddress;
@@ -50,10 +51,12 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 
 import static com.mongodb.internal.connection.SslHelper.enableHostNameVerification;
@@ -104,61 +107,57 @@ final class NettyStream implements Stream {
     @SuppressWarnings("deprecation")
     @Override
     public void openAsync(final AsyncCompletionHandler<Void> handler) {
-        Bootstrap bootstrap = new Bootstrap();
-        bootstrap.group(workerGroup);
-        bootstrap.channel(socketChannelClass);
+        final Queue<SocketAddress> socketAddressQueue = new LinkedList<SocketAddress>(address.getSocketAddresses());
+        initializeChannel(handler, socketAddressQueue);
+    }
 
-        bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, settings.getConnectTimeout(MILLISECONDS));
-        bootstrap.option(ChannelOption.TCP_NODELAY, true);
-        bootstrap.option(ChannelOption.SO_KEEPALIVE, settings.isKeepAlive());
+    @SuppressWarnings("deprecation")
+    public void initializeChannel(final AsyncCompletionHandler<Void> handler, final Queue<SocketAddress> socketAddressQueue) {
+        if (socketAddressQueue.isEmpty()) {
+            handler.failed(new MongoSocketException("Exception opening socket", getAddress()));
+        } else {
+            SocketAddress nextAddress = socketAddressQueue.poll();
 
-        if (settings.getReceiveBufferSize() > 0) {
-            bootstrap.option(ChannelOption.SO_RCVBUF, settings.getReceiveBufferSize());
-        }
-        if (settings.getSendBufferSize() > 0) {
-            bootstrap.option(ChannelOption.SO_SNDBUF, settings.getSendBufferSize());
-        }
-        bootstrap.option(ChannelOption.ALLOCATOR, allocator);
+            Bootstrap bootstrap = new Bootstrap();
+            bootstrap.group(workerGroup);
+            bootstrap.channel(socketChannelClass);
 
-        bootstrap.handler(new ChannelInitializer<SocketChannel>() {
-            @Override
-            public void initChannel(final SocketChannel ch) throws Exception {
-                if (sslSettings.isEnabled()) {
-                    SSLEngine engine = getSslContext().createSSLEngine(address.getHost(), address.getPort());
-                    engine.setUseClientMode(true);
-                    SSLParameters sslParameters = engine.getSSLParameters();
-                    enableSni(address.getHost(), sslParameters);
-                    if (!sslSettings.isInvalidHostNameAllowed()) {
-                        enableHostNameVerification(sslParameters);
-                    }
-                    engine.setSSLParameters(sslParameters);
-                    ch.pipeline().addFirst("ssl", new SslHandler(engine, false));
-                }
-                int readTimeout = settings.getReadTimeout(MILLISECONDS);
-                if (readTimeout > 0) {
-                    ch.pipeline().addLast(READ_HANDLER_NAME, new ReadTimeoutHandler(readTimeout));
-                }
-                ch.pipeline().addLast(new InboundBufferHandler());
+            bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, settings.getConnectTimeout(MILLISECONDS));
+            bootstrap.option(ChannelOption.TCP_NODELAY, true);
+            bootstrap.option(ChannelOption.SO_KEEPALIVE, settings.isKeepAlive());
+
+            if (settings.getReceiveBufferSize() > 0) {
+                bootstrap.option(ChannelOption.SO_RCVBUF, settings.getReceiveBufferSize());
             }
-        });
-        final ChannelFuture channelFuture = bootstrap.connect(address.getHost(), address.getPort());
-        channelFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(final ChannelFuture future) throws Exception {
-                if (future.isSuccess()) {
-                    channel = channelFuture.channel();
-                    channel.closeFuture().addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(final ChannelFuture f2) throws Exception {
-                            handleReadResponse(null, new IOException("The connection to the server was closed"));
+            if (settings.getSendBufferSize() > 0) {
+                bootstrap.option(ChannelOption.SO_SNDBUF, settings.getSendBufferSize());
+            }
+            bootstrap.option(ChannelOption.ALLOCATOR, allocator);
+
+            bootstrap.handler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                public void initChannel(final SocketChannel ch) {
+                    if (sslSettings.isEnabled()) {
+                        SSLEngine engine = getSslContext().createSSLEngine(address.getHost(), address.getPort());
+                        engine.setUseClientMode(true);
+                        SSLParameters sslParameters = engine.getSSLParameters();
+                        enableSni(address.getHost(), sslParameters);
+                        if (!sslSettings.isInvalidHostNameAllowed()) {
+                            enableHostNameVerification(sslParameters);
                         }
-                    });
-                    handler.completed(null);
-                } else {
-                    handler.failed(new MongoSocketOpenException("Exception opening socket", getAddress(), future.cause()));
+                        engine.setSSLParameters(sslParameters);
+                        ch.pipeline().addFirst("ssl", new SslHandler(engine, false));
+                    }
+                    int readTimeout = settings.getReadTimeout(MILLISECONDS);
+                    if (readTimeout > 0) {
+                        ch.pipeline().addLast(READ_HANDLER_NAME, new ReadTimeoutHandler(readTimeout));
+                    }
+                    ch.pipeline().addLast(new InboundBufferHandler());
                 }
-            }
-        });
+            });
+            final ChannelFuture channelFuture = bootstrap.connect(nextAddress);
+            channelFuture.addListener(new OpenChannelFutureListener(socketAddressQueue, channelFuture, handler));
+        }
     }
 
     @Override
@@ -381,6 +380,39 @@ final class NettyStream implements Stream {
                 return t;
             } catch (InterruptedException e) {
                 throw new MongoInterruptedException("Interrupted", e);
+            }
+        }
+    }
+
+    private class OpenChannelFutureListener implements ChannelFutureListener {
+        private final Queue<SocketAddress> socketAddressQueue;
+        private final ChannelFuture chlFuture;
+        private final AsyncCompletionHandler<Void> handler;
+
+        OpenChannelFutureListener(final Queue<SocketAddress> socketAddressQueue, final ChannelFuture chlFuture,
+                                  final AsyncCompletionHandler<Void> handler) {
+            this.socketAddressQueue = socketAddressQueue;
+            this.chlFuture = chlFuture;
+            this.handler = handler;
+        }
+
+        @Override
+        public void operationComplete(final ChannelFuture future) {
+            if (future.isSuccess()) {
+                channel = chlFuture.channel();
+                channel.closeFuture().addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(final ChannelFuture future) {
+                        handleReadResponse(null, new IOException("The connection to the server was closed"));
+                    }
+                });
+                handler.completed(null);
+            } else {
+                if (socketAddressQueue.isEmpty()) {
+                    handler.failed(new MongoSocketOpenException("Exception opening socket", getAddress(), future.cause()));
+                } else {
+                    initializeChannel(handler, socketAddressQueue);
+                }
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
@@ -104,15 +104,13 @@ final class NettyStream implements Stream {
         handler.get();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void openAsync(final AsyncCompletionHandler<Void> handler) {
-        final Queue<SocketAddress> socketAddressQueue = new LinkedList<SocketAddress>(address.getSocketAddresses());
-        initializeChannel(handler, socketAddressQueue);
+        initializeChannel(handler, new LinkedList<SocketAddress>(address.getSocketAddresses()));
     }
 
     @SuppressWarnings("deprecation")
-    public void initializeChannel(final AsyncCompletionHandler<Void> handler, final Queue<SocketAddress> socketAddressQueue) {
+    private void initializeChannel(final AsyncCompletionHandler<Void> handler, final Queue<SocketAddress> socketAddressQueue) {
         if (socketAddressQueue.isEmpty()) {
             handler.failed(new MongoSocketException("Exception opening socket", getAddress()));
         } else {
@@ -386,20 +384,20 @@ final class NettyStream implements Stream {
 
     private class OpenChannelFutureListener implements ChannelFutureListener {
         private final Queue<SocketAddress> socketAddressQueue;
-        private final ChannelFuture chlFuture;
+        private final ChannelFuture channelFuture;
         private final AsyncCompletionHandler<Void> handler;
 
-        OpenChannelFutureListener(final Queue<SocketAddress> socketAddressQueue, final ChannelFuture chlFuture,
+        OpenChannelFutureListener(final Queue<SocketAddress> socketAddressQueue, final ChannelFuture channelFuture,
                                   final AsyncCompletionHandler<Void> handler) {
             this.socketAddressQueue = socketAddressQueue;
-            this.chlFuture = chlFuture;
+            this.channelFuture = channelFuture;
             this.handler = handler;
         }
 
         @Override
         public void operationComplete(final ChannelFuture future) {
             if (future.isSuccess()) {
-                channel = chlFuture.channel();
+                channel = channelFuture.channel();
                 channel.closeFuture().addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(final ChannelFuture future) {

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.MongoSocketException;
 import com.mongodb.MongoSocketOpenException;
 import com.mongodb.MongoSocketReadException;
 import com.mongodb.MongoSocketReadTimeoutException;
@@ -27,6 +28,7 @@ import com.mongodb.connection.Stream;
 import org.bson.ByteBuf;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousChannelGroup;
@@ -34,7 +36,9 @@ import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.CompletionHandler;
 import java.nio.channels.InterruptedByTimeoutException;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.mongodb.assertions.Assertions.isTrue;
@@ -72,22 +76,34 @@ public final class AsynchronousSocketChannelStream implements Stream {
     @Override
     public void openAsync(final AsyncCompletionHandler<Void> handler) {
         isTrue("unopened", channel == null);
-        try {
-            channel = AsynchronousSocketChannel.open(group);
-            channel.setOption(StandardSocketOptions.TCP_NODELAY, true);
-            channel.setOption(StandardSocketOptions.SO_KEEPALIVE, settings.isKeepAlive());
-            if (settings.getReceiveBufferSize() > 0) {
-                channel.setOption(StandardSocketOptions.SO_RCVBUF, settings.getReceiveBufferSize());
-            }
-            if (settings.getSendBufferSize() > 0) {
-                channel.setOption(StandardSocketOptions.SO_SNDBUF, settings.getSendBufferSize());
-            }
+        Queue<SocketAddress> socketAddressQueue = new LinkedList<SocketAddress>(serverAddress.getSocketAddresses());
+        initializeSocketChannel(handler, socketAddressQueue);
+    }
 
-            channel.connect(serverAddress.getSocketAddress(), null, new OpenCompletionHandler(handler));
-        } catch (IOException e) {
-            handler.failed(new MongoSocketOpenException("Exception opening socket", serverAddress, e));
-        } catch (Throwable t) {
-            handler.failed(t);
+    @SuppressWarnings("deprecation")
+    private void initializeSocketChannel(final AsyncCompletionHandler<Void> handler, final Queue<SocketAddress> socketAddressQueue) {
+        if (socketAddressQueue.isEmpty()) {
+            handler.failed(new MongoSocketException("Exception opening socket", serverAddress));
+        } else {
+            SocketAddress socketAddress = socketAddressQueue.poll();
+
+            try {
+                AsynchronousSocketChannel chl = AsynchronousSocketChannel.open(group);
+                chl.setOption(StandardSocketOptions.TCP_NODELAY, true);
+                chl.setOption(StandardSocketOptions.SO_KEEPALIVE, settings.isKeepAlive());
+                if (settings.getReceiveBufferSize() > 0) {
+                    chl.setOption(StandardSocketOptions.SO_RCVBUF, settings.getReceiveBufferSize());
+                }
+                if (settings.getSendBufferSize() > 0) {
+                    chl.setOption(StandardSocketOptions.SO_SNDBUF, settings.getSendBufferSize());
+                }
+
+                chl.connect(socketAddress, null, new OpenCompletionHandler(handler, socketAddressQueue, chl));
+            } catch (IOException e) {
+                handler.failed(new MongoSocketOpenException("Exception opening socket", serverAddress, e));
+            } catch (Throwable t) {
+                handler.failed(t);
+            }
         }
     }
 
@@ -255,12 +271,19 @@ public final class AsynchronousSocketChannelStream implements Stream {
     }
 
     private class OpenCompletionHandler extends BaseCompletionHandler<Void, Void, Object> {
-        OpenCompletionHandler(final AsyncCompletionHandler<Void> handler) {
+        private final Queue<SocketAddress> socketAddressQueue;
+        private final AsynchronousSocketChannel chl;
+
+        OpenCompletionHandler(final AsyncCompletionHandler<Void> handler, final Queue<SocketAddress> socketAddressQueue,
+                              final AsynchronousSocketChannel chl) {
             super(handler);
+            this.socketAddressQueue = socketAddressQueue;
+            this.chl = chl;
         }
 
         @Override
         public void completed(final Void result, final Object attachment) {
+            channel = chl;
             AsyncCompletionHandler<Void> localHandler = getHandlerAndClear();
             localHandler.completed(null);
         }
@@ -268,10 +291,15 @@ public final class AsynchronousSocketChannelStream implements Stream {
         @Override
         public void failed(final Throwable exc, final Object attachment) {
             AsyncCompletionHandler<Void> localHandler = getHandlerAndClear();
-            if (exc instanceof IOException) {
-                localHandler.failed(new MongoSocketOpenException("Exception opening socket", getAddress(), exc));
+
+            if (socketAddressQueue.isEmpty()) {
+                if (exc instanceof IOException) {
+                    localHandler.failed(new MongoSocketOpenException("Exception opening socket", getAddress(), exc));
+                } else {
+                    localHandler.failed(exc);
+                }
             } else {
-                localHandler.failed(exc);
+                initializeSocketChannel(localHandler, socketAddressQueue);
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/FutureAsyncCompletionHandler.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/FutureAsyncCompletionHandler.java
@@ -71,4 +71,5 @@ class FutureAsyncCompletionHandler<T> implements AsyncCompletionHandler<T> {
         }
         return result;
     }
+
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/FutureAsyncCompletionHandler.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/FutureAsyncCompletionHandler.java
@@ -71,5 +71,4 @@ class FutureAsyncCompletionHandler<T> implements AsyncCompletionHandler<T> {
         }
         return result;
     }
-
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
@@ -1,9 +1,11 @@
 package com.mongodb.connection.netty
 
+import category.Slow
 import com.mongodb.MongoSocketOpenException
 import com.mongodb.ServerAddress
 import com.mongodb.connection.SocketSettings
 import com.mongodb.connection.SslSettings
+import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -13,6 +15,7 @@ import static com.mongodb.ClusterFixture.getSslSettings
 
 class NettyStreamSpecification extends Specification {
 
+    @Category(Slow)
     @IgnoreIf({ getSslSettings().isEnabled() })
     def 'should successfully connect with working ip address group'() {
         given:
@@ -37,6 +40,7 @@ class NettyStreamSpecification extends Specification {
         !stream.isClosed()
     }
 
+    @Category(Slow)
     @IgnoreIf({ getSslSettings().isEnabled() })
     def 'should throw exception with non-working ip address group'() {
         given:

--- a/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
@@ -1,0 +1,63 @@
+package com.mongodb.connection.netty
+
+import com.mongodb.MongoSocketOpenException
+import com.mongodb.ServerAddress
+import com.mongodb.connection.SocketSettings
+import com.mongodb.connection.SslSettings
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+import static com.mongodb.ClusterFixture.getSslSettings
+
+class NettyStreamSpecification extends Specification {
+
+    @IgnoreIf({ getSslSettings().isEnabled() })
+    def 'should successfully connect with working ip address group'() {
+        given:
+        def port = 27017
+        SocketSettings socketSettings = SocketSettings.builder().connectTimeout(1000, TimeUnit.MILLISECONDS).build()
+        SslSettings sslSettings = SslSettings.builder().build()
+        def factory = new NettyStreamFactory(socketSettings, sslSettings)
+
+        def inetAddresses = [new InetSocketAddress(InetAddress.getByName('192.168.255.255'), port),
+                             new InetSocketAddress(InetAddress.getByName('1.2.3.4'), port),
+                             new InetSocketAddress(InetAddress.getByName('127.0.0.1'), port)]
+
+        def serverAddress = Stub(ServerAddress)
+        serverAddress.getSocketAddresses() >> inetAddresses
+
+        def stream = factory.create(serverAddress)
+
+        when:
+        stream.open()
+
+        then:
+        !stream.isClosed()
+    }
+
+    @IgnoreIf({ getSslSettings().isEnabled() })
+    def 'should throw exception with non-working ip address group'() {
+        given:
+        def port = 27017
+        SocketSettings socketSettings = SocketSettings.builder().connectTimeout(1000, TimeUnit.MILLISECONDS).build()
+        SslSettings sslSettings = SslSettings.builder().build()
+        def factory = new NettyStreamFactory(socketSettings, sslSettings)
+
+        def inetAddresses = [new InetSocketAddress(InetAddress.getByName('192.168.255.255'), port),
+                             new InetSocketAddress(InetAddress.getByName('1.2.3.4'), port),
+                             new InetSocketAddress(InetAddress.getByName('1.2.3.5'), port)]
+
+        def serverAddress = Stub(ServerAddress)
+        serverAddress.getSocketAddresses() >> inetAddresses
+
+        def stream = factory.create(serverAddress)
+
+        when:
+        stream.open()
+
+        then:
+        thrown(MongoSocketOpenException)
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
@@ -1,0 +1,74 @@
+package com.mongodb.internal.connection
+
+import category.Slow
+import com.mongodb.MongoSocketOpenException
+import com.mongodb.ServerAddress
+import com.mongodb.connection.AsynchronousSocketChannelStreamFactoryFactory
+import com.mongodb.connection.SocketSettings
+import com.mongodb.connection.SslSettings
+import org.junit.experimental.categories.Category
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+import java.nio.channels.AsynchronousChannelGroup
+import java.util.concurrent.Executors
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+
+import static com.mongodb.ClusterFixture.getSslSettings
+
+class AsyncSocketChannelStreamSpecification extends Specification {
+
+    @Category(Slow)
+    @IgnoreIf({ getSslSettings().isEnabled() })
+    def 'should successfully connect with working ip address list'() {
+        given:
+        def port = 27017
+        def socketSettings = SocketSettings.builder().connectTimeout(100, MILLISECONDS).build()
+        def sslSettings = SslSettings.builder().build()
+        def channelGroup = AsynchronousChannelGroup.withThreadPool(Executors.newFixedThreadPool(5))
+        def factoryFactory = AsynchronousSocketChannelStreamFactoryFactory.builder().group(channelGroup).build()
+        def factory = factoryFactory.create(socketSettings, sslSettings)
+        def inetAddresses = [new InetSocketAddress(InetAddress.getByName('192.168.255.255'), port),
+                             new InetSocketAddress(InetAddress.getByName('127.0.0.1'), port)]
+
+        def serverAddress = Stub(ServerAddress)
+        serverAddress.getSocketAddresses() >> inetAddresses
+
+        def stream = factory.create(serverAddress)
+
+        when:
+        stream.open()
+
+        then:
+        !stream.isClosed()
+    }
+
+    @Category(Slow)
+    @IgnoreIf({ getSslSettings().isEnabled() })
+    def 'should fail to connect with non-working ip address list'() {
+        given:
+        def port = 27017
+        def socketSettings = SocketSettings.builder().connectTimeout(100, MILLISECONDS).build()
+        def sslSettings = SslSettings.builder().build()
+        def factoryFactory = AsynchronousSocketChannelStreamFactoryFactory.builder()
+                .group(AsynchronousChannelGroup.withThreadPool(Executors.newFixedThreadPool(5)))
+                .build()
+
+        def factory = factoryFactory.create(socketSettings, sslSettings)
+
+        def inetAddresses = [new InetSocketAddress(InetAddress.getByName('192.168.255.255'), port),
+                             new InetSocketAddress(InetAddress.getByName('1.2.3.4'), port)]
+
+        def serverAddress = Stub(ServerAddress)
+        serverAddress.getSocketAddresses() >> inetAddresses
+
+        def stream = factory.create(serverAddress)
+
+        when:
+        stream.open()
+
+        then:
+        thrown(MongoSocketOpenException)
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
@@ -13,10 +13,12 @@ import spock.lang.Specification
 import java.nio.channels.AsynchronousChannelGroup
 import java.util.concurrent.Executors
 
+import static com.mongodb.ClusterFixture.isNotAtLeastJava7
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 import static com.mongodb.ClusterFixture.getSslSettings
 
+@IgnoreIf({ isNotAtLeastJava7() })
 class AsyncSocketChannelStreamSpecification extends Specification {
 
     @Category(Slow)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/StreamSocketAddressSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/StreamSocketAddressSpecification.groovy
@@ -1,10 +1,12 @@
 package com.mongodb.internal.connection
 
+import category.Slow
 import com.mongodb.MongoSocketOpenException
 import com.mongodb.ServerAddress
 import com.mongodb.connection.BufferProvider
 import com.mongodb.connection.SocketSettings
 import com.mongodb.connection.SslSettings
+import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -15,6 +17,7 @@ import static com.mongodb.ClusterFixture.getSslSettings
 
 class StreamSocketAddressSpecification extends Specification {
 
+    @Category(Slow)
     @IgnoreIf({ getSslSettings().isEnabled() })
     def 'should successfully connect with working ip address group'() {
         given:
@@ -59,6 +62,7 @@ class StreamSocketAddressSpecification extends Specification {
         socketChannelStream?.close()
     }
 
+    @Category(Slow)
     @IgnoreIf({ getSslSettings().isEnabled() })
     def 'should throw exception when attempting to connect with incorrect ip address group'() {
         given:


### PR DESCRIPTION
This commit implements the ip address fallback for the async driver. This applies for both async and netty. Tests are included for this as well.

[Evergreen Patch](https://evergreen.mongodb.com/version/5bb3d667c9ec443d06743b58)
