### PR TITLE
JAVA-2950: Implement support for exhaust cursor in OP_MSG

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/FindOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/FindOptions.java
@@ -56,6 +56,7 @@ public final class FindOptions {
     private boolean returnKey;
     private boolean showRecordId;
     private boolean snapshot;
+    private boolean exhaust;
 
     /**
      * Construct a new instance.
@@ -90,6 +91,7 @@ public final class FindOptions {
         returnKey = from.returnKey;
         showRecordId = from.showRecordId;
         snapshot = from.snapshot;
+        exhaust = from.exhaust;
     }
 
     /**
@@ -605,6 +607,32 @@ public final class FindOptions {
     @Deprecated
     public FindOptions snapshot(final boolean snapshot) {
         this.snapshot = snapshot;
+        return this;
+    }
+
+    /**
+     * Returns the exhaust.
+     *
+     * Determines whether the returned cursor from operation execution will be an exhaust cursor.
+     *
+     * @return the exhaust
+     * @since 3.9
+     */
+    public boolean isExhaust() {
+        return exhaust;
+    }
+
+    /**
+     * Sets the exhaust.
+     *
+     * If true, then the returned cursor will be an exhaust cursor following the execution of the operation.
+     *
+     * @param exhaust the exhaust
+     * @return this
+     * @since 3.9
+     */
+    public FindOptions exhaust(final boolean exhaust) {
+        this.exhaust = exhaust;
         return this;
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/FindOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/FindOptions.java
@@ -613,10 +613,12 @@ public final class FindOptions {
     /**
      * Returns the exhaust.
      *
-     * Determines whether the returned cursor from operation execution will be an exhaust cursor.
+     * Determines whether the returned cursor from operation execution will be an exhaust cursor. If executing on a server
+     * that doesn't support exhaust cursors, this property is ignored.
      *
      * @return the exhaust
      * @since 3.9
+     * @mongodb.server.release 4.2
      */
     public boolean isExhaust() {
         return exhaust;
@@ -625,11 +627,13 @@ public final class FindOptions {
     /**
      * Sets the exhaust.
      *
-     * If true, then the returned cursor will be an exhaust cursor following the execution of the operation.
+     * If true, then the returned cursor will be an exhaust cursor following the execution of the operation. If executing
+     * on a server that doesn't support exhaust cursors, this property is ignored.
      *
      * @param exhaust the exhaust
      * @return this
      * @since 3.9
+     * @mongodb.server.release 4.2
      */
     public FindOptions exhaust(final boolean exhaust) {
         this.exhaust = exhaust;
@@ -660,6 +664,7 @@ public final class FindOptions {
                 + ", returnKey=" + returnKey
                 + ", showRecordId=" + showRecordId
                 + ", snapshot=" + snapshot
+                + ", exhaust=" + exhaust
                 + "}";
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/Connection.java
+++ b/driver-core/src/main/com/mongodb/connection/Connection.java
@@ -118,6 +118,23 @@ public interface Connection extends ReferenceCounted {
                   Decoder<T> commandResultDecoder, SessionContext sessionContext);
 
     /**
+     * Executes the command, setting the exhaust boolean.
+     *
+     * @param <T>                       the type of the result
+     * @param database                  the database to execute the command in
+     * @param command                   the command document
+     * @param commandFieldNameValidator the field name validator for the command document
+     * @param readPreference            the read preference that was applied to get this connection, or null if this is a write operation
+     * @param commandResultDecoder      the decoder for the result
+     * @param sessionContext            the session context
+     * @param exhaust                   true if an exhaust cursor is expected
+     * @return the command result
+     * @since 3.9
+     */
+    <T> T command(String database, BsonDocument command, FieldNameValidator commandFieldNameValidator, ReadPreference readPreference,
+                  Decoder<T> commandResultDecoder, SessionContext sessionContext, boolean exhaust);
+
+    /**
      * Executes the command, consuming as much of the {@code SplittablePayload} as possible.
      *
      * @param <T>                       the type of the result

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -63,6 +63,7 @@ public final class CommandMessage extends RequestMessage {
     private final FieldNameValidator payloadFieldNameValidator;
     private final boolean responseExpected;
     private final ClusterConnectionMode clusterConnectionMode;
+    private volatile boolean exhaust;
 
     CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
                    final ReadPreference readPreference, final MessageSettings settings) {
@@ -184,7 +185,9 @@ public final class CommandMessage extends RequestMessage {
     }
 
     private int getOpMsgResponseExpectedFlagBit() {
-        if (requireOpMsgResponse()) {
+        if (exhaust) {
+            return 1 << 16;
+        } else if (requireOpMsgResponse()) {
             return 0;
         } else {
             return 1 << 1;
@@ -272,6 +275,11 @@ public final class CommandMessage extends RequestMessage {
 
     private static boolean isServerVersionAtLeastThreeDotSix(final MessageSettings settings) {
         return settings.getServerVersion().compareTo(new ServerVersion(3, 6)) >= 0;
+    }
+
+    public CommandMessage setExhaust(final boolean exhaust) {
+        this.exhaust = exhaust;
+        return this;
     }
 
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -63,7 +63,7 @@ public final class CommandMessage extends RequestMessage {
     private final FieldNameValidator payloadFieldNameValidator;
     private final boolean responseExpected;
     private final ClusterConnectionMode clusterConnectionMode;
-    private volatile boolean exhaust;
+    private final boolean exhaust;
 
     CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
                    final ReadPreference readPreference, final MessageSettings settings) {
@@ -75,6 +75,14 @@ public final class CommandMessage extends RequestMessage {
                    final ReadPreference readPreference, final MessageSettings settings, final boolean responseExpected,
                    final SplittablePayload payload, final FieldNameValidator payloadFieldNameValidator,
                    final ClusterConnectionMode clusterConnectionMode) {
+        this(namespace, command, commandFieldNameValidator, readPreference, settings, responseExpected, payload, payloadFieldNameValidator,
+                clusterConnectionMode, false);
+    }
+
+    CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
+                   final ReadPreference readPreference, final MessageSettings settings, final boolean responseExpected,
+                   final SplittablePayload payload, final FieldNameValidator payloadFieldNameValidator,
+                   final ClusterConnectionMode clusterConnectionMode, final boolean exhaust) {
         super(namespace.getFullName(), getOpCode(settings), settings);
         this.namespace = namespace;
         this.command = command;
@@ -84,6 +92,7 @@ public final class CommandMessage extends RequestMessage {
         this.payload = payload;
         this.payloadFieldNameValidator = payloadFieldNameValidator;
         this.clusterConnectionMode = clusterConnectionMode;
+        this.exhaust = exhaust;
     }
 
     BsonDocument getCommandDocument(final ByteBufferBsonOutput bsonOutput) {
@@ -276,10 +285,4 @@ public final class CommandMessage extends RequestMessage {
     private static boolean isServerVersionAtLeastThreeDotSix(final MessageSettings settings) {
         return settings.getServerVersion().compareTo(new ServerVersion(3, 6)) >= 0;
     }
-
-    public CommandMessage setExhaust(final boolean exhaust) {
-        this.exhaust = exhaust;
-        return this;
-    }
-
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandProtocolImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandProtocolImpl.java
@@ -41,17 +41,26 @@ class CommandProtocolImpl<T> implements CommandProtocol<T> {
     private final boolean responseExpected;
     private final ClusterConnectionMode clusterConnectionMode;
     private SessionContext sessionContext;
+    private final boolean exhaust;
 
     CommandProtocolImpl(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
                         final ReadPreference readPreference, final Decoder<T> commandResultDecoder) {
         this(database, command, commandFieldNameValidator, readPreference, commandResultDecoder, true, null, null,
-                ClusterConnectionMode.MULTIPLE);
+                ClusterConnectionMode.MULTIPLE, false);
     }
 
     CommandProtocolImpl(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
                         final ReadPreference readPreference, final Decoder<T> commandResultDecoder, final boolean responseExpected,
                         final SplittablePayload payload, final FieldNameValidator payloadFieldNameValidator,
                         final ClusterConnectionMode clusterConnectionMode) {
+        this(database, command, commandFieldNameValidator, readPreference, commandResultDecoder, responseExpected, payload,
+                payloadFieldNameValidator, clusterConnectionMode, false);
+    }
+
+    CommandProtocolImpl(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
+                        final ReadPreference readPreference, final Decoder<T> commandResultDecoder, final boolean responseExpected,
+                        final SplittablePayload payload, final FieldNameValidator payloadFieldNameValidator,
+                        final ClusterConnectionMode clusterConnectionMode, final boolean exhaust) {
         notNull("database", database);
         this.namespace = new MongoNamespace(notNull("database", database), MongoNamespace.COMMAND_COLLECTION_NAME);
         this.command = notNull("command", command);
@@ -62,6 +71,7 @@ class CommandProtocolImpl<T> implements CommandProtocol<T> {
         this.payload = payload;
         this.payloadFieldNameValidator = payloadFieldNameValidator;
         this.clusterConnectionMode = notNull("clusterConnectionMode", clusterConnectionMode);
+        this.exhaust = exhaust;
 
         isTrueArgument("payloadFieldNameValidator cannot be null if there is a payload.",
                 payload == null || payloadFieldNameValidator != null);
@@ -100,6 +110,6 @@ class CommandProtocolImpl<T> implements CommandProtocol<T> {
     private CommandMessage getCommandMessage(final InternalConnection connection) {
         return new CommandMessage(namespace, command, commandFieldNameValidator, readPreference,
                     getMessageSettings(connection.getDescription()), responseExpected, payload,
-                payloadFieldNameValidator, clusterConnectionMode);
+                payloadFieldNameValidator, clusterConnectionMode).setExhaust(exhaust);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandProtocolImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandProtocolImpl.java
@@ -110,6 +110,6 @@ class CommandProtocolImpl<T> implements CommandProtocol<T> {
     private CommandMessage getCommandMessage(final InternalConnection connection) {
         return new CommandMessage(namespace, command, commandFieldNameValidator, readPreference,
                     getMessageSettings(connection.getDescription()), responseExpected, payload,
-                payloadFieldNameValidator, clusterConnectionMode).setExhaust(exhaust);
+                payloadFieldNameValidator, clusterConnectionMode, exhaust);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerConnection.java
@@ -129,7 +129,15 @@ public class DefaultServerConnection extends AbstractReferenceCounted implements
                          final boolean responseExpected, final SplittablePayload payload,
                          final FieldNameValidator payloadFieldNameValidator) {
         return executeProtocol(new CommandProtocolImpl<T>(database, command, commandFieldNameValidator, readPreference,
-                commandResultDecoder, responseExpected, payload, payloadFieldNameValidator, clusterConnectionMode), sessionContext);
+                commandResultDecoder, responseExpected, payload, payloadFieldNameValidator, clusterConnectionMode, false), sessionContext);
+    }
+
+    @Override
+    public <T> T command(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
+                         final ReadPreference readPreference, final Decoder<T> commandResultDecoder, final SessionContext sessionContext,
+                         final boolean exhaust) {
+        return executeProtocol(new CommandProtocolImpl<T>(database, command, commandFieldNameValidator, readPreference,
+                commandResultDecoder, true, null, null, clusterConnectionMode, exhaust), sessionContext);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/ReplyHeader.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ReplyHeader.java
@@ -190,8 +190,12 @@ public final class ReplyHeader {
         return (responseFlags & QUERY_FAILURE_RESPONSE_FLAG) == QUERY_FAILURE_RESPONSE_FLAG;
     }
 
-    // for unit testing
-    int getOpMsgFlagBits() {
+    /**
+     * Gets the OP_MSG flagbit value.
+     *
+     * @return the OP_MSG flagbit
+     */
+    public int getOpMsgFlagBits() {
         return opMsgFlagBits;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -160,7 +160,8 @@ final class Operations<TDocument> {
                 .maxScan(options.getMaxScan())
                 .returnKey(options.isReturnKey())
                 .showRecordId(options.isShowRecordId())
-                .snapshot(options.isSnapshot());
+                .snapshot(options.isSnapshot())
+                .exhaust(options.isExhaust());
     }
 
     <TResult> DistinctOperation<TResult> distinct(final String fieldName, final Bson filter,

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -176,10 +176,19 @@ final class Operations<TDocument> {
 
     @SuppressWarnings("deprecation")
     <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
-                                                           final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
-                                                           final Collation collation,
-                                                           final Bson hint, final String comment, final Boolean allowDiskUse,
-                                                           final Boolean useCursor) {
+                                                            final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
+                                                            final Collation collation, final Bson hint, final String comment,
+                                                            final Boolean allowDiskUse, final Boolean useCursor) {
+        return aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, comment, allowDiskUse,
+                    useCursor, false);
+    }
+
+    @SuppressWarnings("deprecation")
+    <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
+                                                            final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
+                                                            final Collation collation, final Bson hint, final String comment,
+                                                            final Boolean allowDiskUse, final Boolean useCursor,
+                                                            final boolean exhaust) {
         return new AggregateOperation<TResult>(namespace, toBsonDocumentList(pipeline), codecRegistry.get(resultClass))
                 .maxTime(maxTimeMS, MILLISECONDS)
                 .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
@@ -188,7 +197,8 @@ final class Operations<TDocument> {
                 .useCursor(useCursor)
                 .collation(collation)
                 .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
-                .comment(comment);
+                .comment(comment)
+                .exhaust(exhaust);
 
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
@@ -45,6 +45,10 @@ public final class ServerVersionHelper {
         return serverIsAtLeastVersion(description, new ServerVersion(4, 0));
     }
 
+    public static boolean serverIsAtLeastVersionFourDotOne(final ConnectionDescription description) {
+        return serverIsAtLeastVersion(description, new ServerVersion(4, 1));
+    }
+
     private static boolean serverIsAtLeastVersion(final ConnectionDescription description, final ServerVersion serverVersion) {
         return description.getServerVersion().compareTo(serverVersion) >= 0;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -98,9 +98,10 @@ public final class SyncOperations<TDocument> {
     public <TResult> ReadOperation<BatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
                                                                    final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
                                                                    final Collation collation, final Bson hint, final String comment,
-                                                                   final Boolean allowDiskUse, final Boolean useCursor) {
+                                                                   final Boolean allowDiskUse, final Boolean useCursor,
+                                                                   final boolean exhaust) {
         return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, comment, allowDiskUse,
-                useCursor);
+                useCursor, exhaust);
     }
 
     public WriteOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,

--- a/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
@@ -290,6 +290,36 @@ public class AggregateOperation<T> implements AsyncReadOperation<AsyncBatchCurso
         return this;
     }
 
+    /**
+     * Returns the exhaust.
+     *
+     * Determines whether the returned cursor from operation execution will be an exhaust cursor. If executing on a server
+     * that doesn't support exhaust cursors, this property is ignored.
+     *
+     * @return the exhaust
+     * @since 3.9
+     * @mongodb.server.release 4.2
+     */
+    public boolean getExhaust() {
+        return wrapped.getExhaust();
+    }
+
+    /**
+     * Sets the exhaust.
+     *
+     * If true, then the returned cursor will be an exhaust cursor following the execution of the operation. If executing
+     * on a server that doesn't support exhaust cursors, this property is ignored.
+     *
+     * @param exhaust the exhaust
+     * @return this
+     * @since 3.9
+     * @mongodb.server.release 4.2
+     */
+    public AggregateOperation<T> exhaust(final boolean exhaust) {
+        wrapped.exhaust(exhaust);
+        return this;
+    }
+
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         return wrapped.execute(binding);

--- a/driver-core/src/main/com/mongodb/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateOperationImpl.java
@@ -79,6 +79,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     private long maxAwaitTimeMS;
     private long maxTimeMS;
     private Boolean useCursor;
+    private boolean exhaust;
 
     AggregateOperationImpl(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder) {
         this(namespace, pipeline, decoder, defaultAggregateTarget(namespace.getCollectionName()), defaultPipelineCreator(pipeline));
@@ -184,6 +185,15 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
         return this;
     }
 
+    Boolean getExhaust() {
+        return exhaust;
+    }
+
+    AggregateOperationImpl<T> exhaust(final boolean exhaust) {
+        this.exhaust = exhaust;
+        return this;
+    }
+
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         return withConnection(binding, new CallableWithConnectionAndSource<BatchCursor<T>>() {
@@ -278,7 +288,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
             public BatchCursor<T> apply(final BsonDocument result, final ServerAddress serverAddress) {
                 QueryResult<T> queryResult = createQueryResult(result, connection.getDescription());
                 return new QueryBatchCursor<T>(queryResult, 0, batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder, source,
-                        connection);
+                        connection, exhaust);
             }
         };
     }

--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -92,7 +92,7 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
         }
         if (connectionSource != null) {
             this.connectionSource = connectionSource.retain();
-            this.isExhaust = exhaust && canConnectionBeExhaust();
+            this.isExhaust = exhaust && canConnectionBeExhaust(connection);
         } else {
             this.connectionSource = null;
             this.isExhaust = false;
@@ -108,10 +108,9 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
         }
     }
 
-    private boolean canConnectionBeExhaust() {
-        Connection connection = connectionSource.getConnection();
+    private boolean canConnectionBeExhaust(final Connection connection) {
         if (serverIsAtLeastVersionFourDotOne(connection.getDescription())) {
-            exhaustConnection = connection;
+            exhaustConnection = connection.retain();
             return true;
         }
 

--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -92,7 +92,8 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
         }
         if (connectionSource != null) {
             this.connectionSource = connectionSource.retain();
-            this.isExhaust = exhaust && canConnectionBeExhaust(connection);
+            this.isExhaust = exhaust && serverIsAtLeastVersionFourDotOne(connection.getDescription());
+            this.exhaustConnection = isExhaust ? connection.retain() : null;
         } else {
             this.connectionSource = null;
             this.isExhaust = false;
@@ -106,15 +107,6 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
             this.connectionSource.release();
             this.connectionSource = null;
         }
-    }
-
-    private boolean canConnectionBeExhaust(final Connection connection) {
-        if (serverIsAtLeastVersionFourDotOne(connection.getDescription())) {
-            exhaustConnection = connection.retain();
-            return true;
-        }
-
-        return false;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -40,6 +40,7 @@ import java.util.NoSuchElementException;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotOne;
 import static com.mongodb.operation.CursorHelper.getNumberToReturn;
 import static com.mongodb.operation.OperationHelper.getMoreCursorDocumentToQueryResult;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
@@ -59,6 +60,8 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
     private List<T> nextBatch;
     private int count;
     private volatile boolean closed;
+    private volatile boolean exhaust;
+    private Connection exhaustConnection;
 
     QueryBatchCursor(final QueryResult<T> firstQueryResult, final int limit, final int batchSize, final Decoder<T> decoder) {
         this(firstQueryResult, limit, batchSize, decoder, null);
@@ -71,6 +74,12 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
 
     QueryBatchCursor(final QueryResult<T> firstQueryResult, final int limit, final int batchSize, final long maxTimeMS,
                      final Decoder<T> decoder, final ConnectionSource connectionSource, final Connection connection) {
+        this(firstQueryResult, limit, batchSize, maxTimeMS, decoder, connectionSource, connection, false);
+    }
+
+    QueryBatchCursor(final QueryResult<T> firstQueryResult, final int limit, final int batchSize, final long maxTimeMS,
+                     final Decoder<T> decoder, final ConnectionSource connectionSource, final Connection connection,
+                     final boolean exhaust) {
         isTrueArgument("maxTimeMS >= 0", maxTimeMS >= 0);
         this.maxTimeMS = maxTimeMS;
         this.namespace = firstQueryResult.getNamespace();
@@ -78,6 +87,7 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
         this.limit = limit;
         this.batchSize = batchSize;
         this.decoder = notNull("decoder", decoder);
+        this.exhaust = exhaust;
         if (firstQueryResult.getCursor() != null) {
             notNull("connectionSource", connectionSource);
         }
@@ -96,7 +106,6 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
             this.connectionSource = null;
         }
     }
-
     @Override
     public boolean hasNext() {
         if (closed) {
@@ -216,32 +225,54 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
 
     private void getMore() {
         Connection connection = connectionSource.getConnection();
-        try {
-            if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
-                try {
-                    initFromCommandResult(connection.command(namespace.getDatabaseName(),
-                                                             asGetMoreCommandDocument(),
-                                                             NO_OP_FIELD_NAME_VALIDATOR,
-                                                             ReadPreference.primary(),
-                                                             CommandResultDocumentCodec.create(decoder, "nextBatch"),
-                                                             connectionSource.getSessionContext()));
-                } catch (MongoCommandException e) {
-                    throw translateCommandException(e, serverCursor);
+        if (exhaust && serverIsAtLeastVersionFourDotOne(connection.getDescription())) {
+            if (exhaustConnection == null) {
+                exhaustConnection = connection;
+            }
+
+            try {
+                getMoreHelper(exhaustConnection);
+            } finally {
+                if (serverCursor == null) {
+                    this.exhaustConnection.release();
+                    this.exhaustConnection = null;
                 }
-            } else {
-                QueryResult<T> getMore = connection.getMore(namespace, serverCursor.getId(),
-                        getNumberToReturn(limit, batchSize, count), decoder);
-                initFromQueryResult(getMore);
             }
-            if (limitReached()) {
-                killCursor(connection);
+        } else {
+            try {
+                getMoreHelper(connection);
+            } finally {
+                connection.release();
             }
-            if (serverCursor == null) {
-                this.connectionSource.release();
-                this.connectionSource = null;
+        }
+    }
+
+    private void getMoreHelper(final Connection connection) {
+        if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
+            try {
+                initFromCommandResult(connection.command(namespace.getDatabaseName(),
+                        asGetMoreCommandDocument(),
+                        NO_OP_FIELD_NAME_VALIDATOR,
+                        ReadPreference.primary(),
+                        CommandResultDocumentCodec.create(decoder, "nextBatch"),
+                        connectionSource.getSessionContext(),
+                        exhaust));
+            } catch (MongoCommandException e) {
+                throw translateCommandException(e, serverCursor);
             }
-        } finally {
-            connection.release();
+        } else {
+            QueryResult<T> getMore = connection.getMore(namespace, serverCursor.getId(),
+                    getNumberToReturn(limit, batchSize, count), decoder);
+            initFromQueryResult(getMore);
+        }
+
+        if (limitReached()) {
+            killCursor(connection);
+        }
+
+        if (serverCursor == null) {
+            this.connectionSource.release();
+            this.connectionSource = null;
         }
     }
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/InternalStreamConnectionFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/InternalStreamConnectionFunctionalSpecification.groovy
@@ -21,6 +21,7 @@ import spock.lang.IgnoreIf
 
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.getSslSettings
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
 
 class InternalStreamConnectionFunctionalSpecification extends OperationFunctionalSpecification {
@@ -39,7 +40,7 @@ class InternalStreamConnectionFunctionalSpecification extends OperationFunctiona
             MessageSettings.builder().serverVersion(new ServerVersion([4, 1, 3])).serverType(ServerType.STANDALONE).build(),
             true, null, null, ClusterConnectionMode.SINGLE)
 
-    @IgnoreIf({ !serverVersionAtLeast([4, 1, 3]) })
+    @IgnoreIf({ !serverVersionAtLeast([4, 1, 3]) || getSslSettings().isEnabled() })
     def 'should call sendMessage only once when exhaust is set'() {
         given:
         def collectionHelper = getCollectionHelper()

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/InternalStreamConnectionFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/InternalStreamConnectionFunctionalSpecification.groovy
@@ -1,0 +1,111 @@
+package com.mongodb.internal.connection
+
+import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.ReadPreference
+import com.mongodb.ServerAddress
+import com.mongodb.connection.ByteBufferBsonOutput
+import com.mongodb.connection.ClusterConnectionMode
+import com.mongodb.connection.ClusterId
+import com.mongodb.connection.ServerId
+import com.mongodb.connection.ServerType
+import com.mongodb.connection.ServerVersion
+import com.mongodb.connection.SocketSettings
+import com.mongodb.connection.SocketStreamFactory
+import com.mongodb.connection.SslSettings
+import com.mongodb.internal.validator.NoOpFieldNameValidator
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonString
+import org.bson.codecs.BsonDocumentCodec
+import spock.lang.IgnoreIf
+
+import java.util.concurrent.TimeUnit
+
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
+
+class InternalStreamConnectionFunctionalSpecification extends OperationFunctionalSpecification {
+
+    def serverId = new ServerId(new ClusterId(), new ServerAddress('localhost', 27017))
+    def socketSettings = SocketSettings.builder().connectTimeout(1000, TimeUnit.MILLISECONDS).build()
+    def sslSettings = SslSettings.builder().build()
+    InternalStreamConnection connection = new InternalStreamConnection(serverId, new SocketStreamFactory(socketSettings, sslSettings), [],
+            new TestCommandListener(), new InternalStreamConnectionInitializer([], null, []))
+
+    def fieldNameValidator = new NoOpFieldNameValidator()
+    def sessionContext = NoOpSessionContext.INSTANCE
+
+    def findCommand = new BsonDocument('find', new BsonString(getCollectionName())).append('batchSize', new BsonInt32(1))
+    def findMessage = new CommandMessage(namespace, findCommand, fieldNameValidator, ReadPreference.primary(),
+            MessageSettings.builder().serverVersion(new ServerVersion([4, 1, 3])).serverType(ServerType.STANDALONE).build(),
+            true, null, null, ClusterConnectionMode.SINGLE).setExhaust(false)
+
+    @IgnoreIf({ !serverVersionAtLeast([4, 1, 3]) })
+    def 'should respond with moreToCome flagbit set'() {
+        given:
+        def collectionHelper = getCollectionHelper()
+
+        collectionHelper.insertDocuments([
+                new BsonDocument('x', new BsonInt32(0)),
+                new BsonDocument('x', new BsonInt32(1)),
+                new BsonDocument('x', new BsonInt32(2))
+        ])
+
+        connection.open()
+        def findResult = connection.sendAndReceive(findMessage, new BsonDocumentCodec(), sessionContext)
+
+        when:
+        def getMoreCommand = new BsonDocument('getMore', findResult.getDocument('cursor').getInt64('id'))
+                .append('collection', new BsonString(getCollectionName()))
+                .append('batchSize', new BsonInt32(1))
+        def getMoreMessage = new CommandMessage(namespace, getMoreCommand, fieldNameValidator, ReadPreference.primary(),
+                MessageSettings.builder().serverVersion(new ServerVersion([4, 1, 3])).serverType(ServerType.STANDALONE).build(),
+                true, null, null, ClusterConnectionMode.SINGLE).setExhaust(true)
+
+        def bsonOutput = new ByteBufferBsonOutput(connection)
+
+        getMoreMessage.encode(bsonOutput, sessionContext)
+        connection.sendMessage(bsonOutput.getByteBuffers(), getMoreMessage.getId())
+
+        def response = connection.receiveMessage(getMoreMessage.getId())
+
+        then:
+        response.getReplyHeader().getOpMsgFlagBits() == 2
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast([4, 1, 3]) })
+    def 'should call sendMessage only once when exhaust is set'() {
+        given:
+        def collectionHelper = getCollectionHelper()
+
+        collectionHelper.insertDocuments([
+                new BsonDocument('x', new BsonInt32(0)),
+                new BsonDocument('x', new BsonInt32(1)),
+                new BsonDocument('x', new BsonInt32(2))
+        ])
+
+        InternalStreamConnection connectionSpy = Spy(InternalStreamConnection,
+                constructorArgs:[serverId, new SocketStreamFactory(socketSettings, sslSettings), [],
+                                 new TestCommandListener(), new InternalStreamConnectionInitializer([], null, [])])
+        connectionSpy.open()
+
+        def findResult = connectionSpy.sendAndReceive(findMessage, new BsonDocumentCodec(), sessionContext)
+        def bsonOutput = new ByteBufferBsonOutput(connectionSpy)
+
+        def getMoreCommand = new BsonDocument('getMore', findResult.getDocument('cursor').getInt64('id'))
+                .append('collection', new BsonString(getCollectionName()))
+                .append('batchSize', new BsonInt32(1))
+        def getMoreMessage = new CommandMessage(namespace, getMoreCommand, fieldNameValidator, ReadPreference.primary(),
+                MessageSettings.builder().serverVersion(new ServerVersion([4, 1, 3])).serverType(ServerType.STANDALONE).build(),
+                true, null, null, ClusterConnectionMode.SINGLE).setExhaust(true)
+
+        getMoreMessage.encode(bsonOutput, sessionContext)
+
+        when:
+        for (int i = 0; i < 3; i++) {
+            connectionSpy.sendAndReceive(getMoreMessage, new BsonDocumentCodec(), sessionContext)
+        }
+
+        then:
+        1 * connectionSpy.sendMessage(*_)
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
@@ -90,6 +90,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         operation.getMaxTime(MILLISECONDS) == 0
         operation.getPipeline() == []
         operation.getUseCursor() == null
+        !operation.getExhaust()
     }
 
     def 'should set optional values correctly'(){
@@ -105,6 +106,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
                 .maxAwaitTime(10, MILLISECONDS)
                 .maxTime(10, MILLISECONDS)
                 .useCursor(true)
+                .exhaust(true)
 
         then:
         operation.getAllowDiskUse()
@@ -114,6 +116,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         operation.getMaxTime(MILLISECONDS) == 10
         operation.getUseCursor()
         operation.getHint() == hint
+        operation.getExhaust()
     }
 
     def 'should throw when using invalid hint'() {
@@ -150,6 +153,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
                 .maxAwaitTime(15, MILLISECONDS)
                 .maxTime(10, MILLISECONDS)
                 .useCursor(true)
+                .exhaust(true)
 
         def expectedCommand = new BsonDocument('aggregate', new BsonString(helper.namespace.getCollectionName()))
                 .append('pipeline', new BsonArray(pipeline))

--- a/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
@@ -96,6 +96,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         !operation.isOplogReplay()
         !operation.isPartial()
         !operation.isSlaveOk()
+        !operation.isExhaust()
     }
 
     def 'should set optional values correctly'() {
@@ -120,6 +121,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
                 .slaveOk(true)
                 .oplogReplay(true)
                 .noCursorTimeout(true)
+                .exhaust(true)
 
         then:
         operation.getFilter() == filter
@@ -135,6 +137,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         operation.isOplogReplay()
         operation.isPartial()
         operation.isSlaveOk()
+        operation.isExhaust()
     }
 
     def 'should query with default values'() {
@@ -142,6 +145,22 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         def document = new Document('_id', 1)
         getCollectionHelper().insertDocuments(new DocumentCodec(), document);
         def operation = new FindOperation<Document>(getNamespace(), new DocumentCodec())
+
+        when:
+        def results = executeAndCollectBatchCursorResults(operation, async)
+
+        then:
+        results == [document]
+
+        where:
+        async << [true, false]
+    }
+
+    def 'should query with exhaust set'() {
+        given:
+        def document = new Document('_id', 1)
+        getCollectionHelper().insertDocuments(new DocumentCodec(), document)
+        def operation = new FindOperation<Document>(getNamespace(), new DocumentCodec()).exhaust(true)
 
         when:
         def results = executeAndCollectBatchCursorResults(operation, async)

--- a/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
@@ -156,22 +156,6 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    def 'should query with exhaust set'() {
-        given:
-        def document = new Document('_id', 1)
-        getCollectionHelper().insertDocuments(new DocumentCodec(), document)
-        def operation = new FindOperation<Document>(getNamespace(), new DocumentCodec()).exhaust(true)
-
-        when:
-        def results = executeAndCollectBatchCursorResults(operation, async)
-
-        then:
-        results == [document]
-
-        where:
-        async << [true, false]
-    }
-
     def 'should apply filter'() {
         given:
         def document = new Document('_id', 1)

--- a/driver-core/src/test/functional/com/mongodb/operation/QueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/QueryBatchCursorFunctionalSpecification.groovy
@@ -591,11 +591,21 @@ class QueryBatchCursorFunctionalSpecification extends OperationFunctionalSpecifi
         cursor.iterator().sum { it.size } == 5
     }
 
-    def 'should release connection source if limit is reached on get more when exhaust set'() throws InterruptedException {
+    def 'should exhaust cursor when exhaust is set'() {
         given:
         def firstBatch = executeQuery(3)
 
-        cursor = new QueryBatchCursor<Document>(firstBatch, 5, 3, 0, new DocumentCodec(), connectionSource, null, true)
+        when:
+        def cursor = new QueryBatchCursor<Document>(firstBatch, 10, 2, 0, new DocumentCodec(), connectionSource, null, true)
+
+        then:
+        cursor.iterator().sum { it.size } == 10
+    }
+
+    def 'should release connection source if limit is reached on get more when exhaust set'() throws InterruptedException {
+        given:
+        def firstBatch = executeQuery(3)
+        def cursor = new QueryBatchCursor<Document>(firstBatch, 5, 3, 0, new DocumentCodec(), connectionSource, null, true)
 
         when:
         cursor.next()

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageSpecification.groovy
@@ -53,6 +53,40 @@ class CommandMessageSpecification extends Specification {
     def command = new BsonDocument('find', new BsonString(namespace.collectionName))
     def fieldNameValidator = new NoOpFieldNameValidator()
 
+    def 'should encode command message with OP_MSG and exhaust bit set'() {
+        given:
+        def message = new CommandMessage(namespace, command, fieldNameValidator, ReadPreference.primary(),
+                MessageSettings.builder()
+                        .serverVersion(new ServerVersion(4, 1))
+                        .serverType(ServerType.STANDALONE)
+                        .build(),
+                true, null, null, ClusterConnectionMode.SINGLE).setExhaust(exhaust)
+        def output = new BasicOutputBuffer()
+        def sessionContext = Stub(SessionContext) {
+            hasSession() >> false
+            getClusterTime() >> null
+            getSessionId() >> new BsonDocument('id', new BsonBinary([1, 2, 3] as byte[]))
+            getReadConcern() >> ReadConcern.DEFAULT
+        }
+
+        when:
+        message.encode(output, sessionContext)
+
+        then:
+        def byteBuf = new ByteBufNIO(ByteBuffer.wrap(output.toByteArray()))
+        def messageHeader = new MessageHeader(byteBuf, 512)
+
+        messageHeader.opCode == OpCode.OP_MSG.value
+
+        def replyHeader = new ReplyHeader(byteBuf, messageHeader)
+
+        replyHeader.opMsgFlagBits == result
+
+        where:
+        exhaust << [true, false]
+        result << [1 << 16, 0]
+    }
+
     def 'should encode command message with OP_MSG when server version is >= 3.6'() {
         given:
         def message = new CommandMessage(namespace, command, fieldNameValidator, readPreference,

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageSpecification.groovy
@@ -60,7 +60,7 @@ class CommandMessageSpecification extends Specification {
                         .serverVersion(new ServerVersion(4, 1))
                         .serverType(ServerType.STANDALONE)
                         .build(),
-                true, null, null, ClusterConnectionMode.SINGLE).setExhaust(exhaust)
+                true, null, null, ClusterConnectionMode.SINGLE, exhaust)
         def output = new BasicOutputBuffer()
         def sessionContext = Stub(SessionContext) {
             hasSession() >> false

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnection.java
@@ -126,6 +126,13 @@ class TestConnection implements Connection, AsyncConnection {
     }
 
     @Override
+    public <T> T command(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
+                         final ReadPreference readPreference, final Decoder<T> commandResultDecoder, final SessionContext sessionContext,
+                         final boolean exhaust) {
+        return executeEnqueuedCommandBasedProtocol(sessionContext);
+    }
+
+    @Override
     public <T> void commandAsync(final String database, final BsonDocument command, final boolean slaveOk,
                                  final FieldNameValidator fieldNameValidator,
                                  final Decoder<T> commandResultDecoder, final SingleResultCallback<T> callback) {

--- a/driver-core/src/test/unit/com/mongodb/operation/FindOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/FindOperationUnitSpecification.groovy
@@ -177,6 +177,7 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
                 .returnKey(true)
                 .showRecordId(true)
                 .snapshot(true)
+                .exhaust(exhaust)
 
         expectedCommand.append('filter', operation.getFilter())
                 .append('projection', operation.getProjection())
@@ -218,6 +219,7 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
         commandLimit << [100, 100, 10, null, 100, 100, 100, 10, null, 100]
         commandBatchSize << [10, null, null, 10, null, 10, null, null, 10, null]
         commandSingleBatch << [null, true, true, null, null, null, true, true, null, null]
+        exhaust << [true, false, true, false, true, false, true, false, true, false]
     }
 
     def 'should use the ReadBindings readPreference to set slaveOK'() {

--- a/driver-core/src/test/unit/com/mongodb/operation/QueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/QueryBatchCursorSpecification.groovy
@@ -32,8 +32,10 @@ import org.bson.BsonString
 import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class QueryBatchCursorSpecification extends Specification {
+    @Unroll
     def 'should generate expected command and release connection with batchSize, maxTimeMS, and exhaust'() {
         given:
         def connection = Mock(Connection) {
@@ -41,6 +43,8 @@ class QueryBatchCursorSpecification extends Specification {
                 getServerVersion() >> serverVersion
             }
         }
+        connection.retain() >> connection
+
         def connectionSource = Stub(ConnectionSource) {
             _ * getConnection() >> { connection }
         }

--- a/driver-core/src/test/unit/com/mongodb/operation/QueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/QueryBatchCursorSpecification.groovy
@@ -42,7 +42,7 @@ class QueryBatchCursorSpecification extends Specification {
             }
         }
         def connectionSource = Stub(ConnectionSource) {
-            getConnection() >> { connection }
+            _ * getConnection() >> { connection }
         }
         connectionSource.retain() >> connectionSource
 
@@ -73,7 +73,7 @@ class QueryBatchCursorSpecification extends Specification {
         cursor.hasNext()
 
         then:
-        1 * connection.command(database, expectedCommand, _, _, _, _, exhaust) >> {
+        1 * connection.command(database, expectedCommand, _, _, _, _, _) >> {
             reply
         }
         1 * connection.release()

--- a/driver-sync/src/main/com/mongodb/client/AggregateIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/AggregateIterable.java
@@ -139,4 +139,17 @@ public interface AggregateIterable<TResult> extends MongoIterable<TResult> {
      * @mongodb.server.release 3.6
      */
     AggregateIterable<TResult> hint(@Nullable Bson hint);
+
+    /**
+     * Sets the exhaust.
+     *
+     * If true, then the returned cursor will be an exhaust cursor following the execution of the operation. If executing
+     * on a server that doesn't support exhaust cursors, this property is ignored.
+     *
+     * @param exhaust the exhaust
+     * @return this
+     * @since 3.9
+     * @mongodb.server.release 4.2
+     */
+    AggregateIterable<TResult> exhaust(boolean exhaust);
 }

--- a/driver-sync/src/main/com/mongodb/client/FindIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/FindIterable.java
@@ -249,4 +249,15 @@ public interface FindIterable<TResult> extends MongoIterable<TResult> {
      */
     @Deprecated
     FindIterable<TResult> snapshot(boolean snapshot);
+
+    /**
+     * Sets the exhaust.
+     *
+     * If true, then the returned cursor will be an exhaust cursor following the execution of the operation.
+     *
+     * @param exhaust the exhaust
+     * @return this
+     * @since 3.9
+     */
+    FindIterable<TResult> exhaust(boolean exhaust);
 }

--- a/driver-sync/src/main/com/mongodb/client/FindIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/FindIterable.java
@@ -253,11 +253,13 @@ public interface FindIterable<TResult> extends MongoIterable<TResult> {
     /**
      * Sets the exhaust.
      *
-     * If true, then the returned cursor will be an exhaust cursor following the execution of the operation.
+     * If true, then the returned cursor will be an exhaust cursor following the execution of the operation. If executing
+     * on a server that doesn't support exhaust cursors, this property is ignored.
      *
      * @param exhaust the exhaust
      * @return this
      * @since 3.9
+     * @mongodb.server.release 4.2
      */
     FindIterable<TResult> exhaust(boolean exhaust);
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
@@ -193,6 +193,12 @@ final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResu
         return this;
     }
 
+    @Override
+    public FindIterable<TResult> exhaust(final boolean exhaust) {
+        findOptions.exhaust(exhaust);
+        return this;
+    }
+
     @Nullable
     @Override
     public TResult first() {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
@@ -80,6 +80,7 @@ class AggregateIterableSpecification extends Specification {
                 .collation(collation)
                 .hint(new Document('a', 1))
                 .comment('this is a comment')
+                .exhaust(true)
                 .iterator()
 
         operation = executor.getReadOperation() as AggregateOperation<Document>
@@ -92,7 +93,8 @@ class AggregateIterableSpecification extends Specification {
                 .comment('this is a comment')
                 .maxAwaitTime(99, MILLISECONDS)
                 .maxTime(999, MILLISECONDS)
-                .useCursor(true))
+                .useCursor(true)
+                .exhaust(true))
     }
 
     def 'should build the expected AggregateToCollectionOperation'() {
@@ -111,7 +113,8 @@ class AggregateIterableSpecification extends Specification {
                 .useCursor(true)
                 .collation(collation)
                 .hint(new Document('a', 1))
-                .comment('this is a comment').iterator()
+                .comment('this is a comment')
+                .exhaust(true).iterator()
 
         def operation = executor.getWriteOperation() as AggregateToCollectionOperation
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/FindIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/FindIterableSpecification.groovy
@@ -77,6 +77,7 @@ class FindIterableSpecification extends Specification {
                 .returnKey(false)
                 .showRecordId(false)
                 .snapshot(false)
+                .exhaust(false)
 
         when: 'default input should be as expected'
         findIterable.iterator()
@@ -105,6 +106,7 @@ class FindIterableSpecification extends Specification {
                 .returnKey(false)
                 .showRecordId(false)
                 .snapshot(false)
+                .exhaust(false)
         )
         readPreference == secondary()
 
@@ -131,6 +133,7 @@ class FindIterableSpecification extends Specification {
                 .returnKey(true)
                 .showRecordId(true)
                 .snapshot(true)
+                .exhaust(true)
                 .iterator()
 
         operation = executor.getReadOperation() as FindOperation<Document>
@@ -160,6 +163,7 @@ class FindIterableSpecification extends Specification {
                 .returnKey(true)
                 .showRecordId(true)
                 .snapshot(true)
+                .exhaust(true)
         )
     }
 


### PR DESCRIPTION
This commit allows client applications to specify a cursor to be `exhaustAllowed`. When specified, the corresponding `exhaustAllowed` flagbit in the OP_MSG will be set on requests to the server. Future
`getMore` requests will also not be required, as the next batch of results will already be sitting on the connection.

[Evergreen Patch](https://evergreen.mongodb.com/version/5bbfcaaa0305b92e20a52479)

